### PR TITLE
Fix api update race condition

### DIFF
--- a/assets/scripts/game-loop.js
+++ b/assets/scripts/game-loop.js
@@ -5,10 +5,10 @@ const firstHumanMove = require('./humanMove').firstHumanMove
 const nextAiMove = require('./aiMove').nextAiMove
 
 const gameLoop = function (game) {
-  // if game.cells contains any X or O, prepare the game board for continuing an old game
   $('#exit-game').on('click', () => {
     events.onExitGame(game)
   })
+  // if game.cells contains any X or O, prepare the game board for continuing an old game
   if (game.cells.filter(symbol => symbol === 'X' || symbol === 'O').length > 0) {
     game.setFirstMover()
     ui.populateGameBoard(game.cells)

--- a/assets/scripts/humanMove.js
+++ b/assets/scripts/humanMove.js
@@ -10,6 +10,7 @@ const firstHumanMove = function (game) {
 const nextHumanMove = function (game) {
   $('#game-board').on('click', (event) => {
     if (game.isValidMove(event.target)) {
+      console.log(game.player)
       const selectedCell = $(event.target).data('game-board-index')
       let apiDataFeed
       game.updateGameBoard(selectedCell, game.player)
@@ -26,17 +27,15 @@ const nextHumanMove = function (game) {
       } else {
         apiDataFeed = game.getApiDataFeed(selectedCell)
         api.updateGame(game, apiDataFeed)
-          .then(() => {
-            game.setNextPlayer()
-            ui.displayNextPlayer(game.player)
-            if (game.opponent === 'Computer') {
-              $('#game-board').off()
-              nextAiMove(game)
-            }
-          })
-          .catch()
+        game.setNextPlayer()
+        ui.displayNextPlayer(game.player)
+        if (game.opponent === 'Computer') {
+          $('#game-board').off()
+          nextAiMove(game)
+        }
       }
     } else {
+      console.log(game.player)
       ui.displayInvalidMove(game.player)
     }
   })

--- a/assets/scripts/ui.js
+++ b/assets/scripts/ui.js
@@ -66,8 +66,8 @@ const displayNextPlayer = function (nextPlayer) {
 const displayInvalidMove = function (nextPlayer) {
   $('#game-section .user-notification').text('This field is not available!').removeClass('alert-info').addClass('alert-warning')
   setTimeout(() => {
-    displayNextPlayer(nextPlayer)
     $('#game-section .user-notification').removeClass('alert-warning').addClass('alert-info')
+    displayNextPlayer(nextPlayer)
   }, 5 * 1000)
 }
 


### PR DESCRIPTION
Previously, the next player was only changed to the following player after the api updated successfully. This led to race conditions of multiple clicks.  It was even possible to put two symbols of the same player onto two squares, provided the second square was clicked before the API updated.

This issue was fixed by removing the Promise from the api call.